### PR TITLE
PROJ-40 fix: make prop children optional in withAuthRedirect

### DIFF
--- a/shared/hocs/withAuthRedirect.tsx
+++ b/shared/hocs/withAuthRedirect.tsx
@@ -5,7 +5,7 @@ import React, { ComponentType, ReactNode, useEffect } from 'react'
 import { useAppSelector, useNRouter } from '../hooks'
 
 type Props = {
-  children: ReactNode
+  children?: ReactNode
 }
 
 export function withAuthRedirect<T extends Props>(Component: ComponentType<T>) {


### PR DESCRIPTION
- сделал children не обязательным свойством в withAuthRedirect